### PR TITLE
Do not disable traefik and service_lb

### DIFF
--- a/server_agent_provision/files/install_k3s_server.bash
+++ b/server_agent_provision/files/install_k3s_server.bash
@@ -8,7 +8,6 @@ curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="
     --flannel-iface=eth0\
     --cluster-init\
     --disable servicelb\
-    --disable traefik
     --write-kubeconfig-mode '644'" sh -s -
 
 mkdir ~/.kube/

--- a/server_agent_provision/files/install_k3s_server.bash
+++ b/server_agent_provision/files/install_k3s_server.bash
@@ -7,7 +7,6 @@ curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="
     --kube-apiserver-arg=feature-gates=KubeletInUserNamespace=true\
     --flannel-iface=eth0\
     --cluster-init\
-    --disable servicelb\
     --write-kubeconfig-mode '644'" sh -s -
 
 mkdir ~/.kube/


### PR DESCRIPTION
Needed to make networking to work out of the box. If there is no traeffik and servicelb services in the system, it is not possible to get an ExternalIP.