### PR TITLE
Add an option to use ssh from Proxmox host

### DIFF
--- a/server_agent_provision/config.bash
+++ b/server_agent_provision/config.bash
@@ -21,4 +21,5 @@ export CORES=8
 export RAM=20000
 export DISK_GB=40
 export BASE_APT_PACKAGES="curl vim net-tools"
+export ALLOW_SSHD_ROOT=${ALLOW_SSHD_ROOT:-false}
 # -------------------------------------------


### PR DESCRIPTION
Useful for developing and debugging in LXC instances. Permit the root access using sshd. Dangerous if not in combination with a VPN.