### PR TITLE
Add a test for traefik controller

### DIFF
--- a/server_agent_provision/config.bash
+++ b/server_agent_provision/config.bash
@@ -22,4 +22,7 @@ export RAM=20000
 export DISK_GB=40
 export BASE_APT_PACKAGES="curl vim net-tools"
 export ALLOW_SSHD_ROOT=${ALLOW_SSHD_ROOT:-false}
+
+# testing options
+export TEST_TRAEFIK=${TEST_TRAEFIK:-false}
 # -------------------------------------------

--- a/server_agent_provision/create_k3s_server_agent_proxmox.bash
+++ b/server_agent_provision/create_k3s_server_agent_proxmox.bash
@@ -201,6 +201,10 @@ if [[ ${USE_EXISTING_VMID} -eq 0 ]]; then
   if ${ALLOW_SSHD_ROOT}; then
     _allow_root_login "${VMID_SERVER}"
   fi
+  # Server tests to run
+  if ${TEST_TRAEFIK}; then
+    _pct_exec_file ${VMID_SERVER} "test_whoami_traefik.bash"
+  fi
 
   SERVER_TOKEN=$(_pct_exec ${VMID_SERVER} "cat /var/lib/rancher/k3s/server/node-token" true)
   SERVER_IP=$(_pct_exec ${VMID_SERVER} "ifconfig eth0 | sed -En 's/127.0.0.1//;s/.*inet (addr:)?(([0-9]*\.){3}[0-9]*).*/\2/p'" true)

--- a/server_agent_provision/files/test_whoami_traefik.bash
+++ b/server_agent_provision/files/test_whoami_traefik.bash
@@ -1,0 +1,75 @@
+#!/bin/bash
+set -e
+
+# File runs the whoami example of traefik
+# https://doc.traefik.io/traefik/getting-started/quick-start-with-kubernetes/
+# Useful to see if the configuration of the network is fine
+
+# Install script need local bin in the path
+export PATH=$PATH:/usr/local/bin
+
+cat > /tmp/03-whoami.yml <<EOF1
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: whoami
+  labels:
+    app: whoami
+
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: whoami
+  template:
+    metadata:
+      labels:
+        app: whoami
+    spec:
+      containers:
+        - name: whoami
+          image: traefik/whoami
+          ports:
+            - name: web
+              containerPort: 80
+EOF1
+
+cat > /tmp/03-whoami-services.yml <<EOF2
+apiVersion: v1
+kind: Service
+metadata:
+  name: whoami
+
+spec:
+  ports:
+    - name: web
+      port: 80
+      targetPort: web
+
+  selector:
+    app: whoami
+EOF2
+
+cat > /tmp/04-whoami-ingress.yml <<EOF3
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: whoami-ingress
+spec:
+  rules:
+  - http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: whoami
+            port:
+              name: web
+EOF3
+
+kubectl apply -f /tmp/03-whoami.yml \
+              -f /tmp/03-whoami-services.yml \
+              -f /tmp/04-whoami-ingress.yml
+
+curl -v http://localhost/

--- a/server_agent_provision/files/test_whoami_traefik.bash
+++ b/server_agent_provision/files/test_whoami_traefik.bash
@@ -71,5 +71,3 @@ EOF3
 kubectl apply -f /tmp/03-whoami.yml \
               -f /tmp/03-whoami-services.yml \
               -f /tmp/04-whoami-ingress.yml
-
-curl -v http://localhost/


### PR DESCRIPTION
Add an option to support the testing of the traefik controller. The example is taking from the the main page of traefik.