### PR TITLE
Implement a debugger/dummy platform provider

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,27 @@
+name: Test debug provider
+
+on:
+  push:
+
+jobs:
+  run-shell-script:
+    runs-on: ubuntu-latest
+    env:
+      PROVIDER: debugger
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+
+    - name: Run Shell Script
+      run: |
+        set -e
+        set +x
+        ./server_agent_provision/create_k3s_server_agent_proxmox.bash
+
+    - name: Display server/agent log files
+      run: |
+        echo "SERVER LOG"
+        cat /tmp/.k3_debugger_vmid_server
+        echo
+        echo "AGENT LOG"
+        cat /tmp/.k3_debugger_vmid_agent

--- a/server_agent_provision/providers/debugger/hooks.bash
+++ b/server_agent_provision/providers/debugger/hooks.bash
@@ -1,0 +1,40 @@
+#
+# Promox provider
+#
+# Use pct commmands from the system host to execute installation
+# on Proxmox LXCs.
+#
+
+#
+# Implement the exec and exec_file hook
+# For Proxmox system base use _pvt_ functqions
+#
+
+hook_exec() {
+  local SYSTEM_FILE=${1} CMD=${2} ENABLE_OUTPUT=${3:-false} ERR=false
+
+  echo "sh -c \"${CMD}\"" >> "${SYSTEM_FILE}"
+
+  [[ ${ENABLE_OUTPUT} ]] && echo "${LOG}"
+  return 0
+}
+
+hook_exec_file() {
+  local SYSTEM_FILE=${1} FILE_TO_EXEC=${2} ARG1=${3} ARG2=${4} ARG3=${5} ERR=false
+
+  echo "# Running file: ${FILES_DIR}/${FILE_TO_EXEC}" >> ${SYSTEM_FILE}
+  echo "${FILES_DIR}/${FILE_TO_EXEC} \"${ARG1}\" \"${ARG2}\" \"${ARG3}\"" >> ${SYSTEM_FILE}
+  return 0
+}
+
+#
+# Implement the hook_provision_platform:
+# Use plain text files for debugging
+#
+hook_provision_platform() {
+  VMID_SERVER="/tmp/.k3_debugger_vmid_server"
+  VMID_AGENT="/tmp/.k3_debugger_vmid_agent"
+
+  echo "[ --- ] Created debug system server in file ${VMID_SERVER}"
+  echo "[ --- ] Created debug system agent in file ${VMID_AGENT}"
+}


### PR DESCRIPTION
After refactoring the code in #14, #15 and #16 this PR implements a dummy provider to replace all Proxmox LXC communications with storing the commands in a test file: 9200436d4203df8777e544c2f440818ee4adf0fd

The debugger provider will write in `/tmp/.k3_debugger_vmid_server` and `/tmp/.k3_debugger_vmid_agent` all the instructions executed in each of the nodes, agent and server. For the scripts executed it should provide the path and the arguments used.


This should help to demonstrate the capability of changing the platform provider by writing new custom providers. The PR also adds an smoke testing github actions that just run the debugger provider. 97c84d5b287221cd9e35764db9ce30f2ec313425.