### PR TITLE
Do not use traefik but nginx-ingress as LoadBalancer

### DIFF
--- a/server_agent_provision/create_k3s_server_agent_proxmox.bash
+++ b/server_agent_provision/create_k3s_server_agent_proxmox.bash
@@ -69,3 +69,17 @@ echo "[ --- ]"
 
 # Install the helm packages in the server from the configuration file
 _install_helm_packages "${VMID_SERVER}"
+
+echo "[---] INFO:"
+echo "SERVER_CLUSTER_IP is ${SERVER_IP}"
+if ${ALLOW_SSHD_ROOT}; then
+  echo "  ssh root@${SERVER_IP}"
+fi
+sleep 15
+EXTERNAL_IP=$(_pct_exec ${VMID_SERVER} "/usr/local/bin/kubectl get svc -n ingress-nginx ingress-nginx-controller | tail -1 | awk '{ print \$4 }'" true)
+if  [[ ${EXTERNAL_IP} == "<pending>" ]]; then
+  echo "Waiting for LoadBalancer IP..."
+  sleep 60
+  EXTERNAL_IP=$(_pct_exec ${VMID_SERVER} "/usr/local/bin/kubectl get svc -n ingress-nginx ingress-nginx-controller | tail -1 | awk '{ print \$4 }'" true)
+fi
+echo "EXTERNAL_IP is ${EXTERNAL_IP}"

--- a/server_agent_provision/create_k3s_server_agent_proxmox.bash
+++ b/server_agent_provision/create_k3s_server_agent_proxmox.bash
@@ -76,10 +76,10 @@ if ${ALLOW_SSHD_ROOT}; then
   echo "  ssh root@${SERVER_IP}"
 fi
 sleep 15
-EXTERNAL_IP=$(_pct_exec ${VMID_SERVER} "/usr/local/bin/kubectl get svc -n ingress-nginx ingress-nginx-controller | tail -1 | awk '{ print \$4 }'" true)
+EXTERNAL_IP=$(hook_exec ${VMID_SERVER} "/usr/local/bin/kubectl get svc -n ingress-nginx ingress-nginx-controller | tail -1 | awk '{ print \$4 }'" true)
 if  [[ ${EXTERNAL_IP} == "<pending>" ]]; then
   echo "Waiting for LoadBalancer IP..."
   sleep 60
-  EXTERNAL_IP=$(_pct_exec ${VMID_SERVER} "/usr/local/bin/kubectl get svc -n ingress-nginx ingress-nginx-controller | tail -1 | awk '{ print \$4 }'" true)
+  EXTERNAL_IP=$(hook_exec ${VMID_SERVER} "/usr/local/bin/kubectl get svc -n ingress-nginx ingress-nginx-controller | tail -1 | awk '{ print \$4 }'" true)
 fi
 echo "EXTERNAL_IP is ${EXTERNAL_IP}"

--- a/server_agent_provision/files/install_k3s_server.bash
+++ b/server_agent_provision/files/install_k3s_server.bash
@@ -7,8 +7,15 @@ curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="
     --kube-apiserver-arg=feature-gates=KubeletInUserNamespace=true\
     --flannel-iface=eth0\
     --cluster-init\
+    --disable-traefik\
     --write-kubeconfig-mode '644'" sh -s -
 
 mkdir ~/.kube/
 cp /etc/rancher/k3s/k3s.yaml ~/.kube/config
 chmod 700 ~/.kube/config
+
+# Note the use of the provider/cloud controller here to use a nodeport as External IP
+# see: https://kubernetes.github.io/ingress-nginx/deploy/baremetal/#over-a-nodeport-service
+# The URL can be changed to provider/baremetal but in that case a pool of IPs needs to be
+# provided according to the documentation
+/usr/local/bin/kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v1.8.1/deploy/static/provider/cloud/deploy.yaml

--- a/server_agent_provision/files/install_k3s_server.bash
+++ b/server_agent_provision/files/install_k3s_server.bash
@@ -1,13 +1,16 @@
 #!/bin/bash
 set -e
 
+# Be very carefull touching any space or scapes in this command since
+# it is easy that it ends up not generating a valid systemd file.
+# For debbuging: see /etc/systemd/system/k3s.service
 curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC=" 
     --kubelet-arg=feature-gates=KubeletInUserNamespace=true\
     --kube-controller-manager-arg=feature-gates=KubeletInUserNamespace=true\
     --kube-apiserver-arg=feature-gates=KubeletInUserNamespace=true\
     --flannel-iface=eth0\
     --cluster-init\
-    --disable-traefik\
+    --disable traefik
     --write-kubeconfig-mode '644'" sh -s -
 
 mkdir ~/.kube/


### PR DESCRIPTION
Prefer to use nginx-ingress instead of traefik as loadbalancer to be compatible with current projects. Should not be difficult to make this optional, but let's live with hardcoding it here by now.