### PR TITLE
Support for different ingress controllers

### DIFF
--- a/server_agent_provision/README.md
+++ b/server_agent_provision/README.md
@@ -4,12 +4,6 @@ Minimal provisioner written in bash to setup a k3s server <-> agent
 installation in enviroments where other real provisioning tools can not
 be used.
 
-#### Helm packages in the Server
-
-For installing helm packages inside the server, the plain text configuration
-file [`server_helm_packages`](server_helm_packages) can be used. The format
-is described in the file.
-
 ## Proxmox k3s Server Agent Provision
 
 Simple bash provision script to be run on the Proxmox
@@ -18,10 +12,11 @@ host in order to create a Server and Agent k3s installation.
  * Create LXC instances in Proxmox
  * Install base packages in both instances
  * Install k3s server in one of the LXC
+ * Install/Test ingress controller (nginx-ingress by default) in the k3s server
  * Install k3s agent in the other LXC
  * Connect the k3s agent to the server as k3s node
 
-### Usage with proxmox_lxc
+## Usage with proxmox_lxc
 
 Set up the root password in the secret file and run the script.
 
@@ -41,6 +36,12 @@ For development cases, the provisoning can install only the server if needed:
 ```bash
 PROVIDER=proxmox_lxc ONLY_SERVER=true ./create_k3s_server_agent_proxmox.bash
 ```
+
+### Helm packages in the Server
+
+For installing helm packages inside the server, the plain text configuration
+file [`server_helm_packages`](server_helm_packages) can be used. The format
+is described in the file.
 
 
 ### Configuration

--- a/server_agent_provision/server_helm_packages
+++ b/server_agent_provision/server_helm_packages
@@ -1,17 +1,11 @@
-# File defining the Helm package to be installed in the Server. 
+# File defining the Helm package to be installed in the Server.
 # Format of the file is:
 # package name | helm repo url | version | service to check after installation
 # comments and white lines are ignored.
 
-# chart version 5.19.15 is argo v2.5.10
-argo-cd https://argoproj.github.io/argo-helm 5.19.15 argocd-server
+# examples:
 
-# chart version 1.3.18 is harbor 1.10.17 the required in specs. However, all versions under
-# 1.6.0 fail to install on helm. 1.6.0 is harbor 2.2.0
-harbor https://helm.goharbor.io 1.6.0 harbor-portal
-
-# LTS not in the repo, use latest chart 20.2.1 is promethus v2.43.0
-prometheus https://prometheus-community.github.io/helm-charts 20.2.1 prometheus
-
-# Chart version for 6.54.0 is app version 9.4.7
-grafana https://grafana.github.io/helm-charts 6.54.0 grafana 
+# argo-cd https://argoproj.github.io/argo-helm 5.19.15 argocd-server
+# harbor https://helm.goharbor.io 1.6.0 harbor-portal
+# prometheus https://prometheus-community.github.io/helm-charts 20.2.1 prometheus
+# grafana https://grafana.github.io/helm-charts 6.54.0 grafana


### PR DESCRIPTION
At least traefik and nginx-ingress were tested with this provisioning scripts. Support both by adding using the env variable `INGRESS_CONTROLLER`. By default use nginx-ingress.